### PR TITLE
feat(ngx-auth-firebaseui): add dialogContent for ToS  prior register

### DIFF
--- a/demo/src/app/home/home.component.html
+++ b/demo/src/app/home/home.component.html
@@ -108,7 +108,8 @@
 
           <mat-card-content>
             <ngx-auth-firebaseui (onSuccess)="printUser($event)"
-                                 (onError)="printError($event)">
+                                 (onError)="printError($event)"
+                                 [dialogContent]='dialogContent'>
             </ngx-auth-firebaseui>
           </mat-card-content>
         </mat-card>

--- a/demo/src/app/home/home.component.ts
+++ b/demo/src/app/home/home.component.ts
@@ -13,7 +13,6 @@ import {Subscription} from 'rxjs/internal/Subscription';
   encapsulation: ViewEncapsulation.None,
 })
 export class HomeComponent implements OnInit, OnDestroy {
-
   title = 'app';
   error: boolean;
   userComponent = `<ngx-auth-firebaseui-user></ngx-auth-firebaseui-user>`;
@@ -63,6 +62,9 @@ export class HomeComponent implements OnInit, OnDestroy {
              (onSuccess)="printUser($event)"
              (onError)="printError($event)">
         </ngx-auth-firebaseui>`;
+  dialogContent = `<h1>Terms Of Service</h1>
+                    <p>Please read the following lines carefully. By accepting you recognize the following:</p>
+                    <p>ngx-auth-firebaseui is awesome.</p>`;
 
   viewSourceOfNgxAuthFirebaseuiComponent: boolean;
   viewSourceOfTheUserComponent: boolean;

--- a/src/module/components/auth/auth.component.html
+++ b/src/module/components/auth/auth.component.html
@@ -130,7 +130,7 @@
         <mat-card-content fxLayout="column" fxLayoutAlign="center center">
           <form [formGroup]="signUpFormGroup" (ngSubmit)="signUpFormGroup.valid &&
           authProcess.signUp
-          (signUpFormGroup.value.name,signUpFormGroup.value.email,signUpFormGroup.value.password)">
+          (signUpFormGroup.value.name,signUpFormGroup.value.email,signUpFormGroup.value.password,dialogContent)">
             <div fxLayout="column" fxLayoutAlign="center center">
               <!--name-->
               <mat-form-field appearance="outline" label="Name">

--- a/src/module/components/auth/auth.component.ts
+++ b/src/module/components/auth/auth.component.ts
@@ -30,6 +30,9 @@ export class AuthComponent implements OnInit, OnDestroy {
   @Input()
   guestEnabled = true;
 
+  @Input()
+  dialogContent: string;
+
   @Output()
   onSuccess: any;
 

--- a/src/module/components/auth/before-register.component.html
+++ b/src/module/components/auth/before-register.component.html
@@ -1,0 +1,16 @@
+<mat-dialog-content>
+  <div [innerHtml]="dialogContent"></div>
+</mat-dialog-content>
+
+<mat-dialog-actions>
+  <button mat-button
+          color="warn"
+          (click)="onCloseCancel()">
+    CANCEL
+  </button>
+  <button mat-button
+          color="primary"
+          (click)="onCloseConfirm()">
+    I ACCEPT
+  </button>
+</mat-dialog-actions>

--- a/src/module/components/auth/before-register.component.ts
+++ b/src/module/components/auth/before-register.component.ts
@@ -1,0 +1,26 @@
+import {Component, Inject} from '@angular/core';
+import {MatDialogRef, MAT_DIALOG_DATA} from '@angular/material';
+
+@Component({
+  selector: 'ngx-dialog-tos',
+  templateUrl: 'before-register.component.html',
+})
+export class BeforeRegisterComponent {
+
+  dialogContent: string;
+  constructor(
+    public dialogRef: MatDialogRef<BeforeRegisterComponent>,
+    @Inject(MAT_DIALOG_DATA) public data: any) { }
+
+    onNoClick(): void {
+      this.dialogRef.close(false);
+    }
+
+    onCloseCancel() {
+      this.dialogRef.close(false);
+    }
+
+    onCloseConfirm() {
+      this.dialogRef.close(true);
+    }
+}

--- a/src/module/interfaces/main.interface.ts
+++ b/src/module/interfaces/main.interface.ts
@@ -2,7 +2,7 @@ import {AuthProvider} from '../services/auth-process.service';
 
 export interface ISignUpProcess {
 
-  signUp(name: string, email: string, password: string): any;
+  signUp(name: string, email: string, password: string, dialogContent?: string): any;
 }
 
 export interface ISignInProcess {

--- a/src/module/ngx-auth-firebase-u-i.module.ts
+++ b/src/module/ngx-auth-firebase-u-i.module.ts
@@ -3,6 +3,7 @@ import {NgModule, ModuleWithProviders, InjectionToken} from '@angular/core';
 import {FormsModule, ReactiveFormsModule} from '@angular/forms';
 import {HttpClientModule} from '@angular/common/http';
 import {AuthComponent} from './components/auth/auth.component';
+import {BeforeRegisterComponent} from './components/auth/before-register.component';
 import {UserComponent} from './components/user/user.component';
 import {AuthProvidersComponent} from './components/providers/auth.providers.component';
 import {EmailConfirmationComponent} from './components/email-confirmation/email-confirmation.component';
@@ -72,9 +73,13 @@ export {FirestoreSyncService} from './services/firestore-sync.service';
   ],
   declarations: [
     AuthComponent,
+    BeforeRegisterComponent,
     UserComponent,
     AuthProvidersComponent,
     EmailConfirmationComponent,
+  ],
+  entryComponents: [
+    BeforeRegisterComponent,
   ]
 })
 


### PR DESCRIPTION
My first attempt to implement an optional & customizable Dialog that pops up before registering (to show somebody the Terms of Service).

Optional Input parameter is dialogContent, which can be a string containing HTML - I wasn't sure if more is acceptable or a potential security risk. Therefore the buttons are hard coded in this version.

Maybe somebody knows if it's safe to leave that also open to the implementer? Possibly somebody wants one to tick something that the user has read the ToS... or sometimes not?