### PR TITLE
chore(lint): remove typeof-compare rule

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -92,7 +92,6 @@
         "variable-declaration": "nospace"
       }
     ],
-    "typeof-compare": true,
     "unified-signatures": true,
     "variable-name": false,
     "whitespace": [


### PR DESCRIPTION
it was deprecated in TypeScript 2.2