### PR TITLE
fix(package): error in ngx-auth-firebaseui-avatar

### DIFF
--- a/src/module/components/ngx-auth-firebaseui-avatar/ngx-auth-firebaseui-avatar.component.ts
+++ b/src/module/components/ngx-auth-firebaseui-avatar/ngx-auth-firebaseui-avatar.component.ts
@@ -39,7 +39,7 @@ export class NgxAuthFirebaseuiAvatarComponent implements OnInit {
     this.user$ = this.afa.user;
     this.user$.subscribe((user: User) => {
       this.user = user;
-      this.displayNameInitials = this.getDisplayNameInitials(user.displayName);
+      this.displayNameInitials = user ? this.getDisplayNameInitials(user.displayName) : null;
     });
   }
 


### PR DESCRIPTION
Currently, `<ngx-auth-firebaseui-avatar />` throws an error if there is no current user, e.g.:

```
core.js:7187 ERROR TypeError: Cannot read property 'displayName' of null
    at SafeSubscriber._next (ngx-auth-firebaseui.js:1793)
    at SafeSubscriber.__tryOrUnsub (Subscriber.js:183)
    at SafeSubscriber.next (Subscriber.js:122)
    at Subscriber._next (Subscriber.js:72)
    at Subscriber.next (Subscriber.js:49)
    at angularfire2.js:44
    at ZoneDelegate.invoke (zone-evergreen.js:359)
    at Object.onInvoke (core.js:30892)
    at ZoneDelegate.invoke (zone-evergreen.js:358)
    at Zone.run (zone-evergreen.js:124)
```

This PR fixes the issue