### PR TITLE
hotfix(package): Update @angular/material

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-auth-firebaseui",
-  "version": "2.7.2",
+  "version": "3.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -268,9 +268,9 @@
       }
     },
     "@angular/material": {
-      "version": "7.3.7",
-      "resolved": "https://registry.npmjs.org/@angular/material/-/material-7.3.7.tgz",
-      "integrity": "sha512-Eq+7frkeNGkLOfEtmkmJgR+AgoWajOipXZWWfCSamNfpCcPof82DwvGOpAmgGni9FuN2XFQdqP5MoaffQzIvUA==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@angular/material/-/material-8.0.1.tgz",
+      "integrity": "sha512-BozIS+9yiqFTfXBoZfhFUibY8meDUcv/e+CxhSHyv3vZw9XVTNTbiaX7tX/FX0Ai+1VKnwRTGrKvPKGFSqynCA==",
       "requires": {
         "tslib": "^1.7.1"
       }

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "@angular/fire": "^5.2.1",
     "@angular/flex-layout": "^8.0.0-beta.26",
     "@angular/forms": "^8.0.3",
-    "@angular/material": "^7.3.5",
+    "@angular/material": "^8.0.1",
     "@angular/router": "^8.0.3",
     "firebase": "^6.2.4"
   },
@@ -143,7 +143,7 @@
     "zone.js": "^0.8.29"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "jest": {
     "preset": "jest-preset-angular",


### PR DESCRIPTION
@angular/material was missed upgrade in the 3.0.0 release.
Also it sets the minimum required node version (10) for Angular 8