### PR TITLE
Added missing "Forgot password" button event emitter (solves #352)

### DIFF
--- a/src/module/components/ngx-auth-firebaseui-login/ngx-auth-firebaseui-login.component.html
+++ b/src/module/components/ngx-auth-firebaseui-login/ngx-auth-firebaseui-login.component.html
@@ -47,7 +47,8 @@
                   mat-button
                   class="forgot-password"
                   [color]="color"
-                  type="button">
+                  type="button"
+                  (click)="onResetPasswordRequested.emit()">
             {{forgotPasswordText}}
           </button>
         </div>

--- a/src/module/components/ngx-auth-firebaseui-login/ngx-auth-firebaseui-login.component.ts
+++ b/src/module/components/ngx-auth-firebaseui-login/ngx-auth-firebaseui-login.component.ts
@@ -45,6 +45,7 @@ export class NgxAuthFirebaseuiLoginComponent implements OnInit {
   @Output() onSuccess: any;
   @Output() onError: any;
   @Output() onCreateAccountRequested: EventEmitter<void> = new EventEmitter<void>();
+  @Output() onResetPasswordRequested: EventEmitter<void> = new EventEmitter<void>();
 
   loginForm: FormGroup;
   authProviders = AuthProvider;


### PR DESCRIPTION
The `ngx-auth-firebaseui-login` component did not react to clicks on the "Forgot password" button.
This PR adds an emitter to the component and binds the `(click)` event of the button to the emitter.

This solves issue #352.