### PR TITLE
fix(package): show displayNameInitials only if user photoURL is not a…

### DIFF
--- a/src/module/components/ngx-auth-firebaseui-avatar/ngx-auth-firebaseui-avatar.component.html
+++ b/src/module/components/ngx-auth-firebaseui-avatar/ngx-auth-firebaseui-avatar.component.html
@@ -5,7 +5,7 @@
         [style.background-image]="'url(' + user?.photoURL + ')'"
         style="background-size: cover"
         [matTooltip]="user?.displayName">
-  {{displayNameInitials}}
+  <span *ngIf="user?.photoURL">{{displayNameInitials}}</span>
 </button>
 
 <mat-menu xPosition="before" #posXMenu="matMenu" class="before">
@@ -13,7 +13,7 @@
     <button mat-fab
             [style.background-image]="'url(' + user?.photoURL + ')'"
             style="background-size: cover">
-      {{displayNameInitials}}
+      <span *ngIf="user?.photoURL">{{{displayNameInitials}}</span>
     </button>
     <div fxLayout="column" style="padding-left: 10px; padding-right: 10px">
       <strong mat-card-title>{{user?.displayName}}</strong>


### PR DESCRIPTION
User display name initials are displayed no matter if the user photo is available or not.

Now the initials are displayed if user photo isn't available, like Google did it.