### PR TITLE
photoURL is erasing

### DIFF
--- a/src/module/services/auth-process.service.ts
+++ b/src/module/services/auth-process.service.ts
@@ -208,7 +208,11 @@ export class AuthProcessService implements ISignInProcess, ISignUpProcess {
    * @returns
    */
   public updateProfile(name: string, photoURL: string): Promise<any> {
-    return this.afa.auth.currentUser.updateProfile({displayName: name, photoURL: photoURL});
+    if (!photoURL) {
+      return this.afa.auth.currentUser.updateProfile({displayName: name});
+    } else {
+      return this.afa.auth.currentUser.updateProfile({displayName: name, photoURL: photoURL});
+    }
   }
 
   public deleteAccount(): Promise<any> {


### PR DESCRIPTION
Every time I update my profile, the photoURL is erasing. So I found out that component "user" is calling this function with null input and here we have no check if this url was null or not.
So checking !photoURL and not updating in case of null will solve the problem.