### PR TITLE
refac: switch to login tab on signout

### DIFF
--- a/projects/ngx-auth-firebaseui/src/lib/components/ngx-auth-firebaseui/auth.component.ts
+++ b/projects/ngx-auth-firebaseui/src/lib/components/ngx-auth-firebaseui/auth.component.ts
@@ -249,6 +249,7 @@ export class AuthComponent implements OnInit, AfterViewInit, OnChanges, OnDestro
       await this.authProcess.signOut();
     } finally {
       this.isLoading = false;
+      this.tabIndex = 0;
       this.changeDetectorRef.markForCheck();
     }
   }


### PR DESCRIPTION
@AnthonyNahas I detected some annoying behavior here. If we go through register tab. Then registering or signin with provider from here, if we signOut then it lead us back to the previous tab (e.g. register). 

We should move the user back to signin since it's the most logical next operation after a signout: login again.