### PR TITLE
Remove imports from 'rxjs/internal'

### DIFF
--- a/projects/ngx-auth-firebaseui/src/lib/components/ngx-auth-firebaseui-register/ngx-auth-firebaseui-register.component.ts
+++ b/projects/ngx-auth-firebaseui/src/lib/components/ngx-auth-firebaseui-register/ngx-auth-firebaseui-register.component.ts
@@ -1,7 +1,7 @@
 import {Component, EventEmitter, Inject, Input, OnDestroy, OnInit, Output, PLATFORM_ID, ViewEncapsulation} from '@angular/core';
 import {AbstractControl, FormBuilder, FormGroup, ValidationErrors, ValidatorFn, Validators} from '@angular/forms';
 import {Subject, Subscription} from 'rxjs';
-import {takeUntil} from 'rxjs/internal/operators';
+import {takeUntil} from 'rxjs/operators';
 
 import {NgxAuthFirebaseuiAnimations} from '../../animations';
 import {AuthProcessService} from '../../services/auth-process.service';

--- a/projects/ngx-auth-firebaseui/src/lib/components/ngx-auth-firebaseui/auth.component.ts
+++ b/projects/ngx-auth-firebaseui/src/lib/components/ngx-auth-firebaseui/auth.component.ts
@@ -33,7 +33,7 @@ import {AngularFireAuth} from '@angular/fire/auth';
 import {MatPasswordStrengthComponent} from '@angular-material-extensions/password-strength';
 
 // RXJS
-import {Subscription} from 'rxjs/internal/Subscription';
+import {Subscription} from 'rxjs';
 
 import {LegalityDialogComponent, Theme} from '..';
 import {LegalityDialogParams, LegalityDialogResult, NgxAuthFirebaseUIConfig} from '../../interfaces';

--- a/projects/ngx-auth-firebaseui/src/lib/components/providers/auth.providers.component.spec.ts
+++ b/projects/ngx-auth-firebaseui/src/lib/components/providers/auth.providers.component.spec.ts
@@ -9,7 +9,7 @@ import {FlexLayoutModule} from '@angular/flex-layout';
 import {AuthProcessService, AuthProvider} from '../../services/auth-process.service';
 import {FirestoreSyncService} from '../../services/firestore-sync.service';
 import {AngularFireModule} from '@angular/fire';
-import {BehaviorSubject} from 'rxjs/internal/BehaviorSubject';
+import {BehaviorSubject} from 'rxjs/BehaviorSubject';
 import {AngularFirestore} from '@angular/fire/firestore';
 import {AngularFireAuth} from '@angular/fire/auth';
 import {NgxAuthFirebaseUIConfigToken} from '../../ngx-auth-firebase-u-i.module';

--- a/projects/ngx-auth-firebaseui/src/lib/components/providers/auth.providers.component.spec.ts
+++ b/projects/ngx-auth-firebaseui/src/lib/components/providers/auth.providers.component.spec.ts
@@ -9,7 +9,7 @@ import {FlexLayoutModule} from '@angular/flex-layout';
 import {AuthProcessService, AuthProvider} from '../../services/auth-process.service';
 import {FirestoreSyncService} from '../../services/firestore-sync.service';
 import {AngularFireModule} from '@angular/fire';
-import {BehaviorSubject} from 'rxjs/BehaviorSubject';
+import {BehaviorSubject} from 'rxjs';
 import {AngularFirestore} from '@angular/fire/firestore';
 import {AngularFireAuth} from '@angular/fire/auth';
 import {NgxAuthFirebaseUIConfigToken} from '../../ngx-auth-firebase-u-i.module';


### PR DESCRIPTION
There are some wrong imports to internal RxJs modules that cause some annoying warnings on the angular CLI, this was probably caused by VSCode autocomplete and missed by whoever committed it.

The warning:
```log
Warning: Entry point 'ngx-auth-firebaseui' contains deep imports into '../node_modules/rxjs/internal/operators', '../node_modules/rxjs/internal/Subscription'. This is probably not a problem, but may cause the compilation of entry points to be out of order.
```

Fixes #488

EDIT: This possible only occurs on Angular 9, but I haven't tested it on other ng versions