### PR TITLE
Update ngx-auth-firebaseui-login.component.scss

### DIFF
--- a/projects/ngx-auth-firebaseui/src/lib/components/ngx-auth-firebaseui-login/ngx-auth-firebaseui-login.component.scss
+++ b/projects/ngx-auth-firebaseui/src/lib/components/ngx-auth-firebaseui-login/ngx-auth-firebaseui-login.component.scss
@@ -114,6 +114,7 @@ ngx-auth-firebaseui-login {
 
       button {
         &.google-raised,
+        &.apple-raised,
         &.facebook-raised,
         &.twitter-raised,
         &.github-raised,


### PR DESCRIPTION
class 'apple-raised' was missing in the firebaseui-login component scss. The apple provider button was therefore missing a bottom margin