### PR TITLE
fix: authGuardLoggedInURL not working (#423)

### DIFF
--- a/projects/ngx-auth-firebaseui/src/lib/guards/logged-in.guard.ts
+++ b/projects/ngx-auth-firebaseui/src/lib/guards/logged-in.guard.ts
@@ -31,8 +31,8 @@ export class LoggedInGuard implements CanActivate {
             return true;
           }
         } else {
-          if (this.config.authGuardFallbackURL) {
-            this.router.navigate([`/${this.config.authGuardFallbackURL}`], {queryParams: {redirectUrl: state.url}});
+          if (this.config.authGuardLoggedInURL) {
+            this.router.navigate([`/${this.config.authGuardLoggedInURL}`], {queryParams: {redirectUrl: state.url}});
           }
           return false;
         }


### PR DESCRIPTION
Simple fix on logged-in.guard to enable authGuardLoggedInURL redirect works

Fix: #423