### PR TITLE
environments: fix config typo

### DIFF
--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -4,10 +4,10 @@
 
 export const environment = {
   production: false,
-  config: {}
+  firebaseConfig: {}
 };
 
-// YOU MUST PROVIDE YOUR OWN FIREBASE CONFIG AS config ABOVE
+// YOU MUST PROVIDE YOUR OWN FIREBASE CONFIG AS firebaseConfig ABOVE
 /*
  * For easier debugging in development mode, you can import the following file
  * to ignore zone related error stack frames such as `zone.run`, `zoneDelegate.invokeTask`.


### PR DESCRIPTION
I encountered an error when I first cloned and installed your repo. 

In the environments, the Firebase Configuration object was labeled as `config` in the JSON. In the code, it was referenced as `firebaseConfig`. Rather than change the code, I updated the environments file.